### PR TITLE
Fix includes for alarm/callback

### DIFF
--- a/src/uqm.c
+++ b/src/uqm.c
@@ -47,9 +47,9 @@
 #include "options.h"
 #include "uqmversion.h"
 #include "uqm/comm.h"
+#include "libs/callback.h"
+#include "libs/alarm.h"
 #ifdef NETPLAY
-#	include "libs/callback.h"
-#	include "libs/alarm.h"
 #	include "libs/net.h"
 #	include "uqm/supermelee/netplay/netoptions.h"
 #	include "uqm/supermelee/netplay/netplay.h"


### PR DESCRIPTION
## Summary
- include callback and alarm headers unconditionally so their symbols are available even without NETPLAY

## Testing
- `make -f Makefile.build uqm` *(fails: Simple DirectMedia Layer not found)*
- `./build.sh uqm` *(fails: Simple DirectMedia Layer version 2.x not found)*

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_684b41792e4c8320a3436fd9626884c7